### PR TITLE
Update image-builder-troubleshooting.md

### DIFF
--- a/doc_source/image-builder-troubleshooting.md
+++ b/doc_source/image-builder-troubleshooting.md
@@ -27,4 +27,4 @@ By default, the Amazon EC2 instance that is used for build and test activity is 
   +  **Resolution**: Specify a specific VPC in your pipeline's infrastructure settings\. 
 + **Build fails with "status = 'TimedOut'" and "failure message = 'Step timed out while step is verifying the SSM Agent availability on the target instance\(s\)'"**
   + **Issue**: The instance launched to perform the build operations and execute components was not able to access the Systems Manager endpoint\. 
-  + **Resolutions**: Ensure that the subnet used for your image build has access to and routes to the Systems Manager endpoint\. 
+  + **Resolutions**: Ensure that the subnet used for your image build has access to and routes to the Systems Manager endpoint\. Ensure that the instance profile has the **AmazonSSMManagedInstanceCore** role policy associated with it\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
I encountered an issue where I had the **EC2InstanceProfileForImageBuilder** policy attached to my instance profile, but not **AmazonSSMManagedInstanceCore**. Thus, I was experiencing the **TimedOut** issue. I was initially confused because the suggested resolution was what I was doing (had the instance in a default VPC and security group with public subnet) and I was still receiving the error. Once I added the **AmazonSSMManagedInstanceCore** policy, the issue was resolved. I figured I'd clarify that in the documentation in case anyone else experienced this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
