### PR TITLE
security script is always run

### DIFF
--- a/doc_source/security-best-practices.md
+++ b/doc_source/security-best-practices.md
@@ -12,7 +12,7 @@ When building Linux images using EC2 Image Builder, AWS will enforce the executi
 
 AWS recommends that you test your images to validate the security posture and applicable security compliance levels\. 
 
-The following script is run as a mandatory step when Amazon Linux 2 images are customized with EC2 Image Builder\.
+The following script is run as a mandatory step when Linux images are customized with EC2 Image Builder\.
 
 ```
 #!/bin/bash


### PR DESCRIPTION
Security script provided is run after any distro or version of Linux is built using Image Builder.

*Issue #, if available:*

AWS Support case, but no github issue available. AWS Support confirmed that the script is run every time ec2 image builder completes the build of _all_ linux distributions.

*Description of changes:*

The security clean up script is run at the end of building ALL linux images in ec2 image builder, not only Amazon Linux 2. I am using Red Hat, and I appreciate that the script is being run behind the scenes on my behalf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
