### PR TITLE
Update image-builder-action-modules.md

### DIFF
--- a/doc_source/image-builder-action-modules.md
+++ b/doc_source/image-builder-action-modules.md
@@ -1801,8 +1801,8 @@ If both “include" and "exclude" lists are provided, the resulting list of upda
 
 | Primitive | Description | Type | Required | 
 | --- | --- | --- | --- | 
-| include |  For Windows, you can specify the following: [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-action-modules.html) For Linux, you can specify one or more packages to be included in the list for installation\.  | String List | No | 
-| exclude |  For Windows, you can specify the following: [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-action-modules.html) For Linux, you can specify one or more packages to be excluded from the installation\.  | String List | No | 
+| include |  For Windows, you can specify the following: [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-action-modules.html) For Linux, you can specify one or more packages to be included in the list of updates for installation\.  | String List | No | 
+| exclude |  For Windows, you can specify the following: [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-action-modules.html) For Linux, you can specify one or more packages to be excluded from the list of updates for installation\.  | String List | No | 
 
 **Input example: add support for installing Linux updates**
 


### PR DESCRIPTION
UpdateOS action can only install updates not any new packages . The current wording confuses a small number of customers to believe this action can be used to install new packages. Modified the words to be specific about updates.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
